### PR TITLE
Typo in config

### DIFF
--- a/recipes/_config.rb
+++ b/recipes/_config.rb
@@ -22,7 +22,7 @@ template node[:dhcp][:config_file] do
     :failover => DHCP::Failover.enabled?
     )
   action :create
-  notifies :restart, "service[#{node[:dhcp][:service_name]}", :delayed
+  notifies :restart, "service[#{node[:dhcp][:service_name]}]", :delayed
 end
 
 #


### PR DESCRIPTION
Fix error :

```
ArgumentError: You must have a string like resource_type[name]!
/var/lib/gems/1.9.1/gems/chef-11.4.4/lib/chef/resource_collection.rb:209:in `find_resource_by_string'
```
