### PR TITLE
Fix bug wrt. Chef 10.x.x

### DIFF
--- a/libraries/dynadns.rb
+++ b/libraries/dynadns.rb
@@ -2,13 +2,15 @@
 module DHCP
   module DynaDns 
     class  << self  
-      if  Chef::Version.new(Chef::VERSION) <= Chef::Version.new( "10.16.2" )
+      if  Chef::Version.new(Chef::VERSION) < Chef::Version.new( "11.0.0" )
         include Chef::Mixin::Language
       else
         include Chef::DSL::DataQuery
       end
 
-      attr :node, :zones, :keys
+      attr :node
+      attr :zones
+      attr :keys
 
       def load(node)
         @node = node

--- a/libraries/failover.rb
+++ b/libraries/failover.rb
@@ -2,7 +2,7 @@
 module DHCP
   module Failover
     class << self
-      if  Chef::Version.new(Chef::VERSION) <= Chef::Version.new( "10.16.2" )
+      if  Chef::Version.new(Chef::VERSION) < Chef::Version.new( "11.0.0" )
         include Chef::Mixin::Language
       else
         include Chef::DSL::DataQuery


### PR DESCRIPTION
See also [COOK-2234](https://tickets.opscode.com/browse/COOK-2234).

The altered check allows for using the cookbook with Chef 10.18.2 (and possibly further bugfix releases).

BTW thanks for your work.
Cheers, Stephan
