### PR TITLE
Support dynamic update of a bind server from a subnet.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "spheromak@gmail.com"
 license          "Apache 2.0"
 description      "DHCP"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.1.0"
+version          "2.1.1"
 
 #tested with Ubuntu, assume Debian works similarly
 %w{ debian ubuntu centos redhat }.each do |os|

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -33,7 +33,9 @@ action :add do
       :routers => new_resource.routers,
       :options => new_resource.options,
       :range => new_resource.range,
-      :peer => new_resource.peer
+      :peer => new_resource.peer,
+      :key => new_resource.key,
+      :zones => new_resource.zones
     )
     owner "root"
     group "root"
@@ -54,4 +56,3 @@ action :remove do
   new_resource.updated_by_last_action(f.updated?)
   write_include
 end
-

--- a/recipes/_networks.rb
+++ b/recipes/_networks.rb
@@ -18,7 +18,8 @@ node[:dhcp][:networks].each do |net|
     options   net_bag["options"] || []
     range     net_bag["range"] || ""
     conf_dir  node[:dhcp][:dir]
-    peer  node[:domain] if node[:dhcp][:failover]
+    peer      node[:domain] if node[:dhcp][:failover]
+    key       net_bag["key"] || {}
+    zones     net_bag["zones"] || []
   end
 end
-

--- a/resources/subnet.rb
+++ b/resources/subnet.rb
@@ -9,5 +9,6 @@ attribute :routers, :kind_of => Array, :default => []
 attribute :options, :kind_of => Array, :default => []
 attribute :range,  :kind_of => String
 attribute :peer, :kind_of => String, :default => nil
+attribute :key, :kind_of => Hash, :default => {}
+attribute :zones, :kind_of => Array, :default => []
 attribute :conf_dir, :kind_of => String, :default => "/etc/dhcp"
-

--- a/templates/default/subnet.conf.erb
+++ b/templates/default/subnet.conf.erb
@@ -1,14 +1,14 @@
 # File managed by Chef
 
 subnet <%= @subnet %> netmask <%= @netmask%> {
-<% unless @range.empty? -%>  
+<% unless @range.empty? -%>
 pool {
   <% if @peer -%>
-  failover peer "<%= node[:domain] %>"; 
+  failover peer "<%= node[:domain] %>";
   <% end -%>
   range <%= @range %>;
 }
-<% end -%>  
+<% end -%>
 <% if not @routers.empty? -%>
   option routers <%= @routers.collect! {|i| i }.join(",") %>;
 <% end -%>
@@ -19,5 +19,20 @@ pool {
   <%= option %>;
 <%   end -%>
 <% end -%>
-}
 
+<% if not @key.empty? -%>
+  key <%= @key['name'] %> {
+    algorithm <%= @key['algorithm'] %>;
+    secret "<%= @key['secret'] %>";
+  };
+<% end -%>
+
+<% if not @zones.empty? -%>
+<% @zones.each do |zone| -%>
+  zone <%= zone['zone'] %> {
+    primary <%= zone['primary'] %>;
+    key <%= zone['key'] %>;
+  }
+<% end -%>
+<% end -%>
+}


### PR DESCRIPTION
A quick and dirty hack to allow a subnet to update a bind server.

Having a dhcp_network item like so 

```
{
  "name": "data_bag_item_dhcp_networks_172-30-5-0",
  "json_class": "Chef::DataBagItem",
  "chef_type": "data_bag_item",
  "data_bag": "dhcp_networks",
  "raw_data": {
    "id": "172-30-5-0",
    "routers": [
      "172.30.5.1"
    ],
    "address": "172.30.5.0",
    "netmask": "255.255.255.0",
    "broadcast": "172.30.5.255",
    "range": "172.30.5.13 172.30.5.254",
    "options": [
      "option domain-name-servers 172.30.5.254",
      "option domain-name \"lab.sp\"",
      "ddns-domainname \"lab.sp.\"",
      "ddns-rev-domainname \"5.30.172.in-addr.arpa.\""
    ],
    "key": {
      "name": "dhcpupdate",
      "algorithm": "hmac-md5",
      "secret": "megasecret=="
    },
    "zones": [
      {
        "zone": "lab.sp.",
        "primary": "172.30.5.254",
        "key": "dhcpupdate"
      },
      {
        "zone": "5.30.172.in-addr.arpa",
        "primary": "172.30.5.254",
        "key": "dhcpupdate"
      }
    ]
  }
}
```

produces a subnet config file

```
# File managed by Chef

subnet 172.30.5.0 netmask 255.255.255.0 {
pool {
  range 172.30.5.13 172.30.5.254;
}
  option routers 172.30.5.1;
  option subnet-mask 255.255.255.0;
  option broadcast-address 172.30.5.255;
  ddns-domainname "lab.sp.";
  ddns-rev-domainname "5.30.172.in-addr.arpa.";
  option domain-name "lab.sp";
  option domain-name-servers 172.30.5.254;

  key dhcpupdate {
    algorithm hmac-md5;
    secret "megasecret==";
  };

  zone lab.sp. {
    primary 172.30.5.254;
    key dhcpupdate;
  }
  zone 5.30.172.in-addr.arpa {
    primary 172.30.5.254;
    key dhcpupdate;
  }
}
```

It aint pretty but it works.
