### PR TITLE
change write_config to write_include, write_config doesn't work on ubunt...

### DIFF
--- a/providers/group.rb
+++ b/providers/group.rb
@@ -37,7 +37,7 @@ action :add do
   end
   new_resource.updated_by_last_action(t.updated?)
 
-  write_config
+  write_include
 end
 
 action :remove do
@@ -48,6 +48,6 @@ action :remove do
   end
   new_resource.updated_by_last_action(f.updated?)
 
-  write_config
+  write_include
 end
 


### PR DESCRIPTION
Looked like there's a pull request for this [1] a while ago but somehow it doesn't make it to the master. I've submitted my own change as it's blocking our deployment.

[1] https://github.com/spheromak/dhcp-cook/pull/4
# 
# Error executing action `add` on resource 'dhcp_group[sf-mgmt]'
## NameError

Cannot find a resource for write_config on ubuntu version 12.04
## Cookbook Trace:

/var/chef/cache/cookbooks/dhcp/providers/group.rb:40:in `block in class_from_file'
