### PR TITLE
added ability to pass eval[1] into groups - [1]http://linux.die.net/man/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ If you undefine an entry it will also get removed.
 | `name`      | `String`| `:name_attribute`
 | `hosts`     | `Hash`  | `{}` | This is a hash of host entries that follow the host-databag format. See the example entry in examples directory
 | `parameters`| `Array` |  `[]`
+| `evals`| `Array` |  `[]` | This is an array of multiline strings of eval
 | `conf_dir`  | `String`| `"/etc/dhcp"` | The directory where the config files are stored
 
 ### Example

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -30,9 +30,10 @@ action :add do
     cookbook 'dhcp'
     source 'group.conf.erb'
     variables(
-      name: new_resource.name,
-      parameters: new_resource.parameters,
-      hosts: new_resource.hosts
+      :name => new_resource.name,
+      :parameters => new_resource.parameters,
+      :evals => new_resource.evals,
+      :hosts => new_resource.hosts
     )
     owner 'root'
     group 'root'

--- a/recipes/_groups.rb
+++ b/recipes/_groups.rb
@@ -12,6 +12,7 @@ unless node[:dhcp][:groups].empty?
     next unless group_data
     dhcp_group group do
       parameters  group_data[:parameters]  || []
+      evals  group_data[:evals] || []
       hosts       group_data[:hosts] || []
       conf_dir  node[:dhcp][:dir]
     end

--- a/resources/group.rb
+++ b/resources/group.rb
@@ -3,7 +3,8 @@
 actions :add, :remove
 default_action :add
 
-attribute :name, kind_of: String, name_attribute: true
-attribute :parameters, kind_of: Array, default: []
-attribute :hosts, kind_of: Hash, default: {}
-attribute :conf_dir, kind_of: String, default: '/etc/dhcp'
+attribute :name, :kind_of => String, :name_attribute => true
+attribute :parameters, :kind_of => Array, :default => []
+attribute :evals, :kind_of => Array, :default => []
+attribute :hosts, :kind_of => Hash, :default => {}
+attribute :conf_dir, :kind_of => String, :default => "/etc/dhcp"

--- a/templates/default/group.conf.erb
+++ b/templates/default/group.conf.erb
@@ -3,7 +3,10 @@
 #<%= @name %>
 group  {
 <% @parameters.sort.each do |parameter| -%>
-    <%= parameter %>;
+  <%= parameter %>;
+<% end -%>
+<% @evals.sort.each do |eval| -%>
+<%= eval %>
 <% end -%>
 
 <% @hosts.sort.each do |host,data| -%>


### PR DESCRIPTION
I've needed to be able to pass an dhcpd-eval into the parameters portion of the group to do conditional PXE. Since the existing Parameter option automatically added ";" eval does not needed ";" added. This is a quick way to build a complex evaluation code and pass into the Array as Strings.

Example is below.

ipxe_eval = <<EOF
if exists user-class and option user-class = "iPXE" {
filename "bootstrap.ipxe";
} else {
filename "undionly.kpxe";
}
EOF

group = data_bag_item("dhcp_groups","sj-servers")
dhcp_group group["id"] do
parameters [ "default-lease-time 86400", "next-server #{node[:dhcp][:next_server]}"]
evals [ipxe_eval]
hosts host_data
end
