### PR TITLE
Added ability to pass eval into subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ If you undefine an entry it will also get removed.
 | `options`  |`Array` - `[]`
 | `range`    |`String` 
 | `peer`     |`String` | `nil` | Peer server for this segment
+| `evals`    | `Array` |  `[]` | This is an array of multiline strings of eval
 | `conf_dir` |`String` | `"/etc/dhcp"` 
 
 ### Example

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -38,6 +38,7 @@ action :add do
       options: new_resource.options,
       range: new_resource.range,
       peer: new_resource.peer,
+      evals: new_resource.evals,
       key: new_resource.key,
       zones: new_resource.zones,
       ddns: new_resource.ddns

--- a/recipes/_networks.rb
+++ b/recipes/_networks.rb
@@ -25,6 +25,7 @@ node[:dhcp][:networks].each do |net|
     ddns      data['ddns'] if data.key? 'ddns'
     conf_dir  node[:dhcp][:dir]
     peer      node[:domain] if node[:dhcp][:failover]
+    evals     data[:evals] || []
     key       data['key'] || {}
     zones     data['zones'] || []
   end

--- a/resources/subnet.rb
+++ b/resources/subnet.rb
@@ -11,6 +11,7 @@ attribute :options, kind_of: Array, default: []
 attribute :range, kind_of: String
 attribute :ddns, kind_of: String, default: nil
 attribute :peer, kind_of: String, default: nil
+attribute :evals, kind_of: Array, default: []
 attribute :key, kind_of: Hash, default: {}
 attribute :zones, kind_of: Array, default: []
 attribute :conf_dir, kind_of: String, default: '/etc/dhcp'

--- a/templates/default/subnet.conf.erb
+++ b/templates/default/subnet.conf.erb
@@ -23,6 +23,10 @@ pool {
 <%   end -%>
 <% end -%>
 
+<% @evals.sort.each do |eval| -%>
+<%= eval %>
+<% end -%>
+
 <% unless @key.empty? -%>
   key <%= @key['name'] %> {
     algorithm <%= @key['algorithm'] %>;


### PR DESCRIPTION
To follow up on the work in #23, this adds `eval` support to the subnet LWRP and templates.

I confirmed this passes `rubocop -a` already too.
