### PR TITLE
Cleaning up Kitchen for Ubuntu.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,20 +3,16 @@ driver_plugin: vagrant
 provisioner: chef_zero
 
 platforms:
-- name: centos-6.4_chef-11.4.4
+- name: centos-6.4
   driver_config:
-    box: opscode-centos-6.4_chef-11.4.4
-    box_url:  https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_chef-11.4.4.box
     attributes:
       dhcp:
         interfaces:
           - eth0:0
-- name: ubuntu-12.04_chef-11.4.4
+- name: ubuntu-12.04
   run_list:
     - recipe[ubuntu]
   driver_config:
-    box: opscode-ubuntu-12.04_chef-11.4.4
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_chef-11.4.4.box
     attributes:
       dhcp:
         interfaces:
@@ -33,13 +29,10 @@ suites:
      hosts: all
      networks:
        - 192.168.9.0/24
-     interfaces:
-       - eth0:0
      options:
        'domain-name': "vm"
        'domain-name-servers': 192.168.9.1
 
-suites:
 - name: no_bag
   run_list:
     - recipe[dhcp_net_setup]
@@ -51,8 +44,6 @@ suites:
      hosts: all
      networks:
        - 192.168.9.0/24
-     interfaces:
-       - eth0:0
      options:
        'domain-name': "vm"
        'domain-name-servers': 192.168.9.1

--- a/test/integration/default/serverspec/localhost/default_spec.rb
+++ b/test/integration/default/serverspec/localhost/default_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 # simple example
 describe package( "yum" ) do
-  case backend(Serverspec::Commands::Base).check_os
+  case backend(Serverspec::Commands::Base).check_os[:family]
   when "RedHat"
     it { should be_installed }
   else


### PR DESCRIPTION
Fixed hidden default test-suite.  It should now have all four tests running.  I had to remove the pinned vagrant boxes as the Chef version specified was throwing up some weird dependency problems with mixlib.  I can revert that if needed.  Thanks.
