### PR TITLE
Run on later Chef versions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: vagrant
-  chef_version: 12.19.36
+  require_chef_omnibus: 12.21.3
 
 provisioner:
   name: policyfile_zero

--- a/libraries/dynadns.rb
+++ b/libraries/dynadns.rb
@@ -68,7 +68,8 @@ module DHCP
         # TODO: need to work out the namespace on dns stuff here.
         # TODO: be good to support knife-vault/encrypted bags for keys
         if node.key?(:dns) && node['dns'].key?(:rndc_key)
-          k[node.normal['dns']['rndc_key']] = get_key node['dns']['rndc_key']
+          default_key = node['dns']['rndc_key']
+          k[default_key] = get_key(default_key)
         end
 
         @zones.each { |zone| k[zone['rndc_key']] = get_key zone['rndc_key'] if zone.key? 'rndc_key' }

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -40,7 +40,7 @@ module Dhcp
     # @param [String] sub_dir - The subconfig directory for the config
     #
     def write_include(sub_dir, name)
-      t = template "#{new_resource.conf_dir}/#{sub_dir}/list.conf #{name}" do
+      template "#{new_resource.conf_dir}/#{sub_dir}/list.conf #{name}" do
         path "#{new_resource.conf_dir}/#{sub_dir}/list.conf"
         cookbook 'dhcp'
         source 'list.conf.erb'
@@ -50,7 +50,6 @@ module Dhcp
         variables(files: includes(sub_dir))
         notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
       end
-      new_resource.updated_by_last_action(t.updated?)
     end
 
     #

--- a/providers/class.rb
+++ b/providers/class.rb
@@ -3,20 +3,21 @@ include Dhcp::Helpers
 action :add do
   run_context.include_recipe 'dhcp::_service'
 
-  directory "#{new_resource.conf_dir}/classes.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/classes.d"
-  end
+  converge_by("Add #{new_resource.name}") do
+    directory "#{new_resource.conf_dir}/classes.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/classes.d"
+    end
 
-  t = template "#{new_resource.conf_dir}/classes.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'class.conf.erb'
-    variables name: new_resource.name, match: new_resource.match, subclasses: new_resource.subclasses
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-  new_resource.updated_by_last_action(t.updated?)
+    template "#{new_resource.conf_dir}/classes.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'class.conf.erb'
+      variables name: new_resource.name, match: new_resource.match, subclasses: new_resource.subclasses
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'classes.d', new_resource.name
+    write_include 'classes.d', new_resource.name
+  end
 end

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -1,35 +1,37 @@
 include Dhcp::Helpers
 
 action :add do
-  directory "#{new_resource.conf_dir}/groups.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/groups.d"
-  end
+  converge_by("Add #{new_resource.name}") do
+    directory "#{new_resource.conf_dir}/groups.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/groups.d"
+    end
 
-  t = template "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'group.conf.erb'
-    variables(
-      name: new_resource.name,
-      parameters: new_resource.parameters,
-      evals: new_resource.evals,
-      hosts: new_resource.hosts
-    )
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-  new_resource.updated_by_last_action(t.updated?)
+    template "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'group.conf.erb'
+      variables(
+        name: new_resource.name,
+        parameters: new_resource.parameters,
+        evals: new_resource.evals,
+        hosts: new_resource.hosts
+      )
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'groups.d', new_resource.name
+    write_include 'groups.d', new_resource.name
+  end
 end
 
 action :remove do
-  f = file "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
-    action :delete
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-  new_resource.updated_by_last_action(f.updated?)
+  converge_by("Remove #{new_resource.name}") do
+    file "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
+      action :delete
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'groups.d', new_resource.name
+    write_include 'groups.d', new_resource.name
+  end
 end

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -1,36 +1,38 @@
 include Dhcp::Helpers
 
 action :add do
-  directory "#{new_resource.conf_dir}/hosts.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/hosts.d"
-  end
+  converge_by("Adding #{new_resource.name}") do
+    directory "#{new_resource.conf_dir}/hosts.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/hosts.d"
+    end
 
-  t = template "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'host.conf.erb'
-    variables(
-      name: new_resource.name,
-      hostname: new_resource.hostname,
-      macaddress: new_resource.macaddress,
-      ipaddress: new_resource.ipaddress,
-      options: new_resource.options,
-      parameters: new_resource.parameters
-    )
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    template "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'host.conf.erb'
+      variables(
+        name: new_resource.name,
+        hostname: new_resource.hostname,
+        macaddress: new_resource.macaddress,
+        ipaddress: new_resource.ipaddress,
+        options: new_resource.options,
+        parameters: new_resource.parameters
+      )
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
+    write_include 'hosts.d', new_resource.name
   end
-  new_resource.updated_by_last_action(t.updated?)
-  write_include 'hosts.d', new_resource.name
 end
 
 action :remove do
-  f = file "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
-    action :delete
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-  new_resource.updated_by_last_action(f.updated?)
+  converge_by("Remove #{new_resource.name}") do
+    file "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
+      action :delete
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'hosts.d', new_resource.name
+    write_include 'hosts.d', new_resource.name
+  end
 end

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -3,42 +3,44 @@ include Dhcp::Helpers
 action :add do
   run_context.include_recipe 'dhcp::_service'
 
-  directory "#{new_resource.conf_dir}/subnets.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/subnets.d"
-  end
+  converge_by("Adding #{new_resource.name}") do
+    directory "#{new_resource.conf_dir}/subnets.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/subnets.d"
+    end
 
-  t = template "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'subnet.conf.erb'
-    variables(
-      subnet: new_resource.subnet,
-      netmask: new_resource.netmask,
-      broadcast: new_resource.broadcast,
-      pools: new_resource.pools,
-      routers: new_resource.routers,
-      options: new_resource.options,
-      evals: new_resource.evals,
-      key: new_resource.key,
-      zones: new_resource.zones,
-      ddns: new_resource.ddns,
-      next_server: new_resource.next_server
-    )
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-  new_resource.updated_by_last_action(t.updated?)
+    template "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'subnet.conf.erb'
+      variables(
+        subnet: new_resource.subnet,
+        netmask: new_resource.netmask,
+        broadcast: new_resource.broadcast,
+        pools: new_resource.pools,
+        routers: new_resource.routers,
+        options: new_resource.options,
+        evals: new_resource.evals,
+        key: new_resource.key,
+        zones: new_resource.zones,
+        ddns: new_resource.ddns,
+        next_server: new_resource.next_server
+      )
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'subnets.d', new_resource.name
+    write_include 'subnets.d', new_resource.name
+  end
 end
 
 action :remove do
-  f = file "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
-    action :delete
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    notifies :send_notification, new_resource, :immediately
+  converge_by("Remove #{new_resource.name}") do
+    file "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
+      action :delete
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+      notifies :send_notification, new_resource, :immediately
+    end
+    write_include 'subnets.d', new_resource.name
   end
-  new_resource.updated_by_last_action(f.updated?)
-  write_include 'subnets.d', new_resource.name
 end


### PR DESCRIPTION
### Description

Trying to use this cookbook with later Chef releases but am running into
strange problems. Here I saved a node attribute that got re-used several
times as the existing method of calling seemed to overwrite the value so
`get_key` was getting an empty hash.

I'm not sure this case is fully exercised in the Test Kitchen suite. Also made a change to specify the version of the Chef Client.

### Issues Resolved

My wrapper cookbook was getting:

```       ================================================================================
       Recipe Compile Error in /tmp/kitchen/cache/cookbooks/nfl-dhcp/recipes/default.rb
       ================================================================================

       Chef::Exceptions::InvalidDataBagItemID
       --------------------------------------
       Data Bag items must have an id matching /^[\.\-[:alnum:]_]+$/, you gave: {}

       Cookbook Trace:
       ---------------
         /tmp/kitchen/cache/cookbooks/dhcp/libraries/dynadns.rb:93:in `get_key'
         /tmp/kitchen/cache/cookbooks/dhcp/libraries/dynadns.rb:76:in `keys'
         /tmp/kitchen/cache/cookbooks/dhcp/recipes/_config.rb:20:in `block in from_file'
         /tmp/kitchen/cache/cookbooks/dhcp/recipes/_config.rb:9:in `from_file'
         /tmp/kitchen/cache/cookbooks/dhcp/recipes/server.rb:26:in `from_file'
         /tmp/kitchen/cache/cookbooks/nfl-dhcp/recipes/default.rb:9:in `from_file'
```
### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable