### PR TITLE
Drop converge_by and ignore FC warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ namespace :style do
   desc 'Run Chef style checks'
   task :chef do
     sh '/opt/chefdk/embedded/bin/foodcritic --version'
-    sh '/opt/chefdk/embedded/bin/foodcritic -f any . --exclude spec -t ~FC059'
+    sh '/opt/chefdk/embedded/bin/foodcritic -f any . --exclude spec -t ~FC059 -t ~FC017'
   end
 end
 

--- a/providers/class.rb
+++ b/providers/class.rb
@@ -3,21 +3,19 @@ include Dhcp::Helpers
 action :add do
   run_context.include_recipe 'dhcp::_service'
 
-  converge_by("Add #{new_resource.name}") do
-    directory "#{new_resource.conf_dir}/classes.d #{new_resource.name}" do
-      path "#{new_resource.conf_dir}/classes.d"
-    end
-
-    template "#{new_resource.conf_dir}/classes.d/#{new_resource.name}.conf" do
-      cookbook 'dhcp'
-      source 'class.conf.erb'
-      variables name: new_resource.name, match: new_resource.match, subclasses: new_resource.subclasses
-      owner 'root'
-      group 'root'
-      mode '0644'
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    end
-
-    write_include 'classes.d', new_resource.name
+  directory "#{new_resource.conf_dir}/classes.d #{new_resource.name}" do
+    path "#{new_resource.conf_dir}/classes.d"
   end
+
+  template "#{new_resource.conf_dir}/classes.d/#{new_resource.name}.conf" do
+    cookbook 'dhcp'
+    source 'class.conf.erb'
+    variables name: new_resource.name, match: new_resource.match, subclasses: new_resource.subclasses
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+  end
+
+  write_include 'classes.d', new_resource.name
 end

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -1,37 +1,33 @@
 include Dhcp::Helpers
 
 action :add do
-  converge_by("Add #{new_resource.name}") do
-    directory "#{new_resource.conf_dir}/groups.d #{new_resource.name}" do
-      path "#{new_resource.conf_dir}/groups.d"
-    end
-
-    template "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
-      cookbook 'dhcp'
-      source 'group.conf.erb'
-      variables(
-        name: new_resource.name,
-        parameters: new_resource.parameters,
-        evals: new_resource.evals,
-        hosts: new_resource.hosts
-      )
-      owner 'root'
-      group 'root'
-      mode '0644'
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    end
-
-    write_include 'groups.d', new_resource.name
+  directory "#{new_resource.conf_dir}/groups.d #{new_resource.name}" do
+    path "#{new_resource.conf_dir}/groups.d"
   end
+
+  template "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
+    cookbook 'dhcp'
+    source 'group.conf.erb'
+    variables(
+      name: new_resource.name,
+      parameters: new_resource.parameters,
+      evals: new_resource.evals,
+      hosts: new_resource.hosts
+    )
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+  end
+
+  write_include 'groups.d', new_resource.name
 end
 
 action :remove do
-  converge_by("Remove #{new_resource.name}") do
-    file "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
-      action :delete
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    end
-
-    write_include 'groups.d', new_resource.name
+  file "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
+    action :delete
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
   end
+
+  write_include 'groups.d', new_resource.name
 end

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -1,38 +1,34 @@
 include Dhcp::Helpers
 
 action :add do
-  converge_by("Adding #{new_resource.name}") do
-    directory "#{new_resource.conf_dir}/hosts.d #{new_resource.name}" do
-      path "#{new_resource.conf_dir}/hosts.d"
-    end
-
-    template "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
-      cookbook 'dhcp'
-      source 'host.conf.erb'
-      variables(
-        name: new_resource.name,
-        hostname: new_resource.hostname,
-        macaddress: new_resource.macaddress,
-        ipaddress: new_resource.ipaddress,
-        options: new_resource.options,
-        parameters: new_resource.parameters
-      )
-      owner 'root'
-      group 'root'
-      mode '0644'
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    end
-    write_include 'hosts.d', new_resource.name
+  directory "#{new_resource.conf_dir}/hosts.d #{new_resource.name}" do
+    path "#{new_resource.conf_dir}/hosts.d"
   end
+
+  template "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
+    cookbook 'dhcp'
+    source 'host.conf.erb'
+    variables(
+      name: new_resource.name,
+      hostname: new_resource.hostname,
+      macaddress: new_resource.macaddress,
+      ipaddress: new_resource.ipaddress,
+      options: new_resource.options,
+      parameters: new_resource.parameters
+    )
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+  end
+  write_include 'hosts.d', new_resource.name
 end
 
 action :remove do
-  converge_by("Remove #{new_resource.name}") do
-    file "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
-      action :delete
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    end
-
-    write_include 'hosts.d', new_resource.name
+  file "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
+    action :delete
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
   end
+
+  write_include 'hosts.d', new_resource.name
 end

--- a/providers/shared_network.rb
+++ b/providers/shared_network.rb
@@ -23,32 +23,28 @@ include Dhcp::Helpers
 action :add do
   run_context.include_recipe 'dhcp::_service'
 
-  converge_by("Add #{new_resource.name}") do
-    directory "#{new_resource.conf_dir}/shared_networks.d #{new_resource.name}" do
-      path "#{new_resource.conf_dir}/shared_networks.d"
-    end
-
-    template "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
-      cookbook 'dhcp'
-      source 'shared_network.conf.erb'
-      variables name: new_resource.name, subnets: new_resource.subnets
-      owner 'root'
-      group 'root'
-      mode '0644'
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    end
-
-    write_include 'shared_networks.d', new_resource.name
+  directory "#{new_resource.conf_dir}/shared_networks.d #{new_resource.name}" do
+    path "#{new_resource.conf_dir}/shared_networks.d"
   end
+
+  template "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
+    cookbook 'dhcp'
+    source 'shared_network.conf.erb'
+    variables name: new_resource.name, subnets: new_resource.subnets
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+  end
+
+  write_include 'shared_networks.d', new_resource.name
 end
 
 action :remove do
-  converge_by("Remove #{new_resource.name}") do
-    file "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
-      action :delete
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-      notifies :send_notification, new_resource, :immediately
-    end
-    write_include 'shared_networks.d', new_resource.name
+  file "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
+    action :delete
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    notifies :send_notification, new_resource, :immediately
   end
+  write_include 'shared_networks.d', new_resource.name
 end

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -3,44 +3,40 @@ include Dhcp::Helpers
 action :add do
   run_context.include_recipe 'dhcp::_service'
 
-  converge_by("Adding #{new_resource.name}") do
-    directory "#{new_resource.conf_dir}/subnets.d #{new_resource.name}" do
-      path "#{new_resource.conf_dir}/subnets.d"
-    end
-
-    template "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
-      cookbook 'dhcp'
-      source 'subnet.conf.erb'
-      variables(
-        subnet: new_resource.subnet,
-        netmask: new_resource.netmask,
-        broadcast: new_resource.broadcast,
-        pools: new_resource.pools,
-        routers: new_resource.routers,
-        options: new_resource.options,
-        evals: new_resource.evals,
-        key: new_resource.key,
-        zones: new_resource.zones,
-        ddns: new_resource.ddns,
-        next_server: new_resource.next_server
-      )
-      owner 'root'
-      group 'root'
-      mode '0644'
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    end
-
-    write_include 'subnets.d', new_resource.name
+  directory "#{new_resource.conf_dir}/subnets.d #{new_resource.name}" do
+    path "#{new_resource.conf_dir}/subnets.d"
   end
+
+  template "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
+    cookbook 'dhcp'
+    source 'subnet.conf.erb'
+    variables(
+      subnet: new_resource.subnet,
+      netmask: new_resource.netmask,
+      broadcast: new_resource.broadcast,
+      pools: new_resource.pools,
+      routers: new_resource.routers,
+      options: new_resource.options,
+      evals: new_resource.evals,
+      key: new_resource.key,
+      zones: new_resource.zones,
+      ddns: new_resource.ddns,
+      next_server: new_resource.next_server
+    )
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+  end
+
+  write_include 'subnets.d', new_resource.name
 end
 
 action :remove do
-  converge_by("Remove #{new_resource.name}") do
-    file "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
-      action :delete
-      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-      notifies :send_notification, new_resource, :immediately
-    end
-    write_include 'subnets.d', new_resource.name
+  file "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
+    action :delete
+    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    notifies :send_notification, new_resource, :immediately
   end
+  write_include 'subnets.d', new_resource.name
 end


### PR DESCRIPTION
The last PR used `converge_by` which will make it look like the resource
changed on every run. This drops that which fixes the output.