### PR TITLE
Always use the root context

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -2,7 +2,7 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: 12.19.36
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport:
   name: dokken

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: vagrant
-  require_chef_omnibus: 12.21.3
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 provisioner:
   name: policyfile_zero

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,14 @@ env:
 # CHEF_VERSION is only for unit tests, no for test-kitchen:
   - TESTS="style unit"
 # Split up the test-kitchen run to avoid exceeding 50 minutes:
-  - TESTS="integration" KITCHEN_INSTANCE=default-centos-6
-  - TESTS="integration" KITCHEN_INSTANCE=default-centos-7
-  - TESTS="integration" KITCHEN_INSTANCE=default-ubuntu-1404
-  - TESTS="integration" KITCHEN_INSTANCE=default-ubuntu-1604
+  - CHEF_VERSION=12 TESTS="integration" KITCHEN_INSTANCE=default-centos-6
+  - CHEF_VERSION=12 TESTS="integration" KITCHEN_INSTANCE=default-centos-7
+  - CHEF_VERSION=12 TESTS="integration" KITCHEN_INSTANCE=default-ubuntu-1404
+  - CHEF_VERSION=12 TESTS="integration" KITCHEN_INSTANCE=default-ubuntu-1604
+  - CHEF_VERSION=13 TESTS="integration" KITCHEN_INSTANCE=default-centos-6
+  - CHEF_VERSION=13 TESTS="integration" KITCHEN_INSTANCE=default-centos-7
+  - CHEF_VERSION=13 TESTS="integration" KITCHEN_INSTANCE=default-ubuntu-1404
+  - CHEF_VERSION=13 TESTS="integration" KITCHEN_INSTANCE=default-ubuntu-1604
 
 install: echo "skip bundle install"
 

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ namespace :style do
   desc 'Run Chef style checks'
   task :chef do
     sh '/opt/chefdk/embedded/bin/foodcritic --version'
-    sh '/opt/chefdk/embedded/bin/foodcritic -f any . --exclude spec -t ~FC059 -t ~FC017'
+    sh '/opt/chefdk/embedded/bin/foodcritic -f any . --exclude spec'
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -27,11 +27,13 @@ module Dhcp
     #
     # @return [Array<String>] An array of config files for the subconfig
     def includes(sub_dir)
-      run_context.resource_collection.map do |resource|
-        next unless resource_match? resource
-        next unless resource.action == :add || resource.action.include?(:add)
-        "#{resource.conf_dir}/#{sub_dir}/#{resource.name}.conf"
-      end.compact
+      with_run_context :root do
+        run_context.resource_collection.map do |resource|
+          next unless resource_match? resource
+          next unless resource.action == :add || resource.action.include?(:add)
+          "#{resource.conf_dir}/#{sub_dir}/#{resource.name}.conf"
+        end.compact
+      end
     end
 
     #

--- a/providers/class.rb
+++ b/providers/class.rb
@@ -1,21 +1,24 @@
 include Dhcp::Helpers
 
+use_inline_resources
 action :add do
-  run_context.include_recipe 'dhcp::_service'
+  with_run_context :root do
+    run_context.include_recipe 'dhcp::_service'
 
-  directory "#{new_resource.conf_dir}/classes.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/classes.d"
+    directory "#{new_resource.conf_dir}/classes.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/classes.d"
+    end
+
+    template "#{new_resource.conf_dir}/classes.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'class.conf.erb'
+      variables name: new_resource.name, match: new_resource.match, subclasses: new_resource.subclasses
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
+
+    write_include 'classes.d', new_resource.name
   end
-
-  template "#{new_resource.conf_dir}/classes.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'class.conf.erb'
-    variables name: new_resource.name, match: new_resource.match, subclasses: new_resource.subclasses
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-
-  write_include 'classes.d', new_resource.name
 end

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -1,33 +1,38 @@
 include Dhcp::Helpers
+use_inline_resources
 
 action :add do
-  directory "#{new_resource.conf_dir}/groups.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/groups.d"
-  end
+  with_run_context :root do
+    directory "#{new_resource.conf_dir}/groups.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/groups.d"
+    end
 
-  template "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'group.conf.erb'
-    variables(
-      name: new_resource.name,
-      parameters: new_resource.parameters,
-      evals: new_resource.evals,
-      hosts: new_resource.hosts
-    )
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
+    template "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'group.conf.erb'
+      variables(
+        name: new_resource.name,
+        parameters: new_resource.parameters,
+        evals: new_resource.evals,
+        hosts: new_resource.hosts
+      )
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'groups.d', new_resource.name
+    write_include 'groups.d', new_resource.name
+  end
 end
 
 action :remove do
-  file "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
-    action :delete
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
+  with_run_context :root do
+    file "#{new_resource.conf_dir}/groups.d/#{new_resource.name}.conf" do
+      action :delete
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'groups.d', new_resource.name
+    write_include 'groups.d', new_resource.name
+  end
 end

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -1,34 +1,39 @@
 include Dhcp::Helpers
 
+use_inline_resources
 action :add do
-  directory "#{new_resource.conf_dir}/hosts.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/hosts.d"
-  end
+  with_run_context :root do
+    directory "#{new_resource.conf_dir}/hosts.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/hosts.d"
+    end
 
-  template "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'host.conf.erb'
-    variables(
-      name: new_resource.name,
-      hostname: new_resource.hostname,
-      macaddress: new_resource.macaddress,
-      ipaddress: new_resource.ipaddress,
-      options: new_resource.options,
-      parameters: new_resource.parameters
-    )
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    template "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'host.conf.erb'
+      variables(
+        name: new_resource.name,
+        hostname: new_resource.hostname,
+        macaddress: new_resource.macaddress,
+        ipaddress: new_resource.ipaddress,
+        options: new_resource.options,
+        parameters: new_resource.parameters
+      )
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
+    write_include 'hosts.d', new_resource.name
   end
-  write_include 'hosts.d', new_resource.name
 end
 
 action :remove do
-  file "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
-    action :delete
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
+  with_run_context :root do
+    file "#{new_resource.conf_dir}/hosts.d/#{new_resource.name}.conf" do
+      action :delete
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
 
-  write_include 'hosts.d', new_resource.name
+    write_include 'hosts.d', new_resource.name
+  end
 end

--- a/providers/shared_network.rb
+++ b/providers/shared_network.rb
@@ -19,32 +19,37 @@
 #
 
 include Dhcp::Helpers
+use_inline_resources
 
 action :add do
-  run_context.include_recipe 'dhcp::_service'
+  with_run_context :root do
+    run_context.include_recipe 'dhcp::_service'
 
-  directory "#{new_resource.conf_dir}/shared_networks.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/shared_networks.d"
+    directory "#{new_resource.conf_dir}/shared_networks.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/shared_networks.d"
+    end
+
+    template "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'shared_network.conf.erb'
+      variables name: new_resource.name, subnets: new_resource.subnets
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
+
+    write_include 'shared_networks.d', new_resource.name
   end
-
-  template "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'shared_network.conf.erb'
-    variables name: new_resource.name, subnets: new_resource.subnets
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-
-  write_include 'shared_networks.d', new_resource.name
 end
 
 action :remove do
-  file "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
-    action :delete
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    notifies :send_notification, new_resource, :immediately
+  with_run_context :root do
+    file "#{new_resource.conf_dir}/shared_networks.d/#{new_resource.name}.conf" do
+      action :delete
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+      notifies :send_notification, new_resource, :immediately
+    end
+    write_include 'shared_networks.d', new_resource.name
   end
-  write_include 'shared_networks.d', new_resource.name
 end

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -1,42 +1,48 @@
 include Dhcp::Helpers
 
+use_inline_resources
 action :add do
-  run_context.include_recipe 'dhcp::_service'
+  with_run_context :root do
+    run_context.include_recipe 'dhcp::_service'
 
-  directory "#{new_resource.conf_dir}/subnets.d #{new_resource.name}" do
-    path "#{new_resource.conf_dir}/subnets.d"
+    directory "#{new_resource.conf_dir}/subnets.d #{new_resource.name}" do
+      path "#{new_resource.conf_dir}/subnets.d"
+    end
+
+    template "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
+      cookbook 'dhcp'
+      source 'subnet.conf.erb'
+      variables(
+        subnet: new_resource.subnet,
+        netmask: new_resource.netmask,
+        broadcast: new_resource.broadcast,
+        pools: new_resource.pools,
+        routers: new_resource.routers,
+        options: new_resource.options,
+        evals: new_resource.evals,
+        key: new_resource.key,
+        zones: new_resource.zones,
+        ddns: new_resource.ddns,
+        next_server: new_resource.next_server
+      )
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+    end
+
+    write_include 'subnets.d', new_resource.name
   end
-
-  template "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
-    cookbook 'dhcp'
-    source 'subnet.conf.erb'
-    variables(
-      subnet: new_resource.subnet,
-      netmask: new_resource.netmask,
-      broadcast: new_resource.broadcast,
-      pools: new_resource.pools,
-      routers: new_resource.routers,
-      options: new_resource.options,
-      evals: new_resource.evals,
-      key: new_resource.key,
-      zones: new_resource.zones,
-      ddns: new_resource.ddns,
-      next_server: new_resource.next_server
-    )
-    owner 'root'
-    group 'root'
-    mode '0644'
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-  end
-
-  write_include 'subnets.d', new_resource.name
 end
 
 action :remove do
-  file "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
-    action :delete
-    notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
-    notifies :send_notification, new_resource, :immediately
+  with_run_context :root do
+    file "#{new_resource.conf_dir}/subnets.d/#{new_resource.name}.conf" do
+      action :delete
+      notifies :restart, "service[#{node['dhcp']['service_name']}]", :delayed
+      notifies :send_notification, new_resource, :immediately
+    end
+
+    write_include 'subnets.d', new_resource.name
   end
-  write_include 'subnets.d', new_resource.name
 end


### PR DESCRIPTION
This cookbook works partially by inspecting the run list to figure out
which resources are being used. Inline resources has changed Chef's
behaviour to have multiple runlist contexts, which breaks this.

This change forces all the resources to go into the root context which
allows the accumulator to work.

At the same time, this PR also splits up the TestKitchen tests to go
against both Chef 12 and 13.