### PR TITLE
Fixes misplaced closing brace for dhcpd hooks

### DIFF
--- a/templates/default/dhcpd.conf.erb
+++ b/templates/default/dhcpd.conf.erb
@@ -21,8 +21,8 @@ on <%= key %> {
 <% value.each do |v| -%>
   <%= v %>;
 <% end -%>
-<% end -%>
 }
+<% end -%>
 <% end -%>
 
 <% unless @keys.nil? || @keys.empty? -%>

--- a/test/cookbooks/dhcp_attributes/attributes/attribute_driver.rb
+++ b/test/cookbooks/dhcp_attributes/attributes/attribute_driver.rb
@@ -27,3 +27,8 @@ default['dhcp']['shared_network_data']['mysharedattrnetwork']['subnets']['192.16
   'range'       => '192.168.14.50 192.168.14.240',
   'next_server' => '192.168.14.11',
 }
+
+default['dhcp']['hooks'] = {
+  'commit' => ['use-host-decl-names on'],
+  'release' => ['use-host-decl-names on'],
+}

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -27,4 +27,6 @@ describe file('/etc/dhcp/dhcpd.conf') do
   it { should be_file }
   its(:content) { should match %r{^include "/etc/dhcp/extra1.conf";} }
   its(:content) { should match %r{^include "/etc/dhcp/extra2.conf";} }
+  its(:content) { should match "on commit {\n  use-host-decl-names on;\n}" }
+  its(:content) { should match "on release {\n  use-host-decl-names on;\n}" }
 end


### PR DESCRIPTION
### Description

This resolves an issue where if multiple hooks are configured for dhcpd,
only one closing `}` is placed after the final hook. However the proper
syntax is for there to be a closing brace for each hook.

### Issues Resolved

Did not create an issue for this. 

### Contribution Check List

- [✔] All tests pass.
- [✔] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable