### PR TITLE
Removes deprecated Chef::Mixin::Language module

### DIFF
--- a/libraries/dynadns.rb
+++ b/libraries/dynadns.rb
@@ -3,10 +3,9 @@ module DHCP
   module DynaDns
     class << self
       if Gem::Version.new(Chef::VERSION) <= Gem::Version.new('10.16.2')
-        include Chef::Mixin::Language
-      else
-        include Chef::DSL::DataQuery
+        include Chef::DSL::PlatformIntrospection
       end
+      include Chef::DSL::DataQuery
 
       attr_accessor :node
       attr_accessor :zones, :keys

--- a/libraries/dynadns.rb
+++ b/libraries/dynadns.rb
@@ -2,9 +2,6 @@ module DHCP
   # methods for managing rndc key data and dynadns bind masters
   module DynaDns
     class << self
-      if Gem::Version.new(Chef::VERSION) <= Gem::Version.new('10.16.2')
-        include Chef::DSL::PlatformIntrospection
-      end
       include Chef::DSL::DataQuery
 
       attr_accessor :node

--- a/libraries/failover.rb
+++ b/libraries/failover.rb
@@ -2,9 +2,6 @@ module DHCP
   # methods for detecthing and reporting on failover role/peers
   module Failover
     class << self
-      if  Gem::Version.new(Chef::VERSION) <= Gem::Version.new('11.0.0')
-        include Chef::DSL::PlatformIntrospection
-      end
       include Chef::DSL::DataQuery
 
       attr_reader :node

--- a/libraries/failover.rb
+++ b/libraries/failover.rb
@@ -3,10 +3,9 @@ module DHCP
   module Failover
     class << self
       if  Gem::Version.new(Chef::VERSION) <= Gem::Version.new('11.0.0')
-        include Chef::Mixin::Language
-      else
-        include Chef::DSL::DataQuery
+        include Chef::DSL::PlatformIntrospection
       end
+      include Chef::DSL::DataQuery
 
       attr_reader :node
 


### PR DESCRIPTION
### Description

The module is now deprecated and will be removed in Chef 14. The module is split into `Chef::DSL::PlatformIntrospection` and `Chef::DSL::DataQuery`. 

### Issues Resolved

This fixes the FC100 warnings. No issue created. 

### Contribution Check List

- [✓] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable