### PR TITLE
Require Chef 13 and remove inline_resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ Large parts were borrowed from work initially done by Dell, extended by Atalanta
 
 ## Chef-client
 
-- 12.7+
-
-## Limitations
+- 13+
 
 - only setup to handle ipv4
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures DHCP'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-chef_version      '>= 12.7' if respond_to?(:chef_version)
+chef_version      '>= 13.0'
 source_url        'https://github.com/sous-chefs/dhcp'
 issues_url        'https://github.com/sous-chefs/dhcp/issues'
 version           '6.0.0'

--- a/providers/class.rb
+++ b/providers/class.rb
@@ -1,6 +1,5 @@
 include Dhcp::Helpers
 
-use_inline_resources
 action :add do
   with_run_context :root do
     run_context.include_recipe 'dhcp::_service'

--- a/providers/group.rb
+++ b/providers/group.rb
@@ -1,5 +1,4 @@
 include Dhcp::Helpers
-use_inline_resources
 
 action :add do
   with_run_context :root do

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -1,6 +1,5 @@
 include Dhcp::Helpers
 
-use_inline_resources
 action :add do
   with_run_context :root do
     directory "#{new_resource.conf_dir}/hosts.d #{new_resource.name}" do

--- a/providers/shared_network.rb
+++ b/providers/shared_network.rb
@@ -19,7 +19,6 @@
 #
 
 include Dhcp::Helpers
-use_inline_resources
 
 action :add do
   with_run_context :root do

--- a/providers/subnet.rb
+++ b/providers/subnet.rb
@@ -1,6 +1,5 @@
 include Dhcp::Helpers
 
-use_inline_resources
 action :add do
   with_run_context :root do
     run_context.include_recipe 'dhcp::_service'


### PR DESCRIPTION
This is the default in Chef 13+ and resolves a Foodcritic warning for
the cookbook.

Signed-off-by: Tim Smith <tsmith@chef.io>