### PR TITLE
Hacktoverfest fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,12 @@ lint_and_unit: &lint_and_unit
   - danger
   - lint-yaml
   - lint-markdown
-
 version: 2.1
 orbs:
   kitchen: sous-chefs/kitchen@2
-
 workflows:
   kitchen:
     jobs:
-      # Lint and Unit Test
       - kitchen/yamllint:
           name: lint-yaml
       - kitchen/mdlint:
@@ -22,9 +19,19 @@ workflows:
           context: Danger
       - kitchen/delivery:
           name: delivery
-
       - kitchen/dokken-single:
-          name: default
-          suite: default
-          requires:
-            *lint_and_unit
+          name: default-debian-8
+          suite: default-debian-8
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-centos-7
+          suite: default-centos-7
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-ubuntu-1604
+          suite: default-ubuntu-1604
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-fedora-30
+          suite: default-fedora-30
+          requires: *lint_and_unit

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-AllCops:
-  Exclude:
-    - 'Dangerfile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# dhcp Cookbook CHANGELOG
+# CHANGELOG
 
-## Unreleased
+## 6.1.0 (2019-10-19)
 
+- Converted all LWRPs to Custom Resources
+- Ran latest cookstyle fixes
 - Migrated testing to circleci
 
 ## 6.0.0 (2018-03-04)

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,13 +25,13 @@ def test_changes?
   false
 end
 
-fail 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+failure 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a CHANGELOG entry.'
+  failure 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,8 +3,7 @@ maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and configures DHCP'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-chef_version      '>= 13.0' if respond_to?(:chef_version)
+chef_version      '>= 13.0'
 source_url        'https://github.com/sous-chefs/dhcp'
 issues_url        'https://github.com/sous-chefs/dhcp/issues'
 version           '6.0.0'


### PR DESCRIPTION

# Description

Fixes for:
- builds to be parallel
- run latest cookstyle
- remove rubocop.yml
- Dangerfile to use failure instead of fail

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

Describe what this change achieves

## Issues Resolved

#121 #122 #124 #125 
## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
