### PR TITLE
Add configuration test before running an impacting service action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 7.1.0 (2020-05-18)
+
+- Add configuration test option to the `dhcp_service` resource
+
 ## 7.0.0 (2020-04-17)
 
 Version 7.0.0 is a **major** change! Please see [UPGRADING.md](./UPGRADING.md).

--- a/documentation/dhcp_config.md
+++ b/documentation/dhcp_config.md
@@ -15,9 +15,8 @@ Introduced: v7.0.0
 
 | Name                   | Type          | Default                          | Description                                                         | Allowed Values      |
 | ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- | ------------------- |
-| `comment`              | String        | `nil`                            | Comment to add to the configuration file                            |                     |
 | `ip_version`           | Symbol        | `:ipv4`                          | Select DHCP or DHCPv6 server to configure                           | `:ipv4`, `:ipv6`    |
-| `conf_dir`             | String        | `/etc/dhcp/dhcpd(6).d/classes.d` | Directory to create configuration file in                           |                     |
+| `config_file`          | String        | `/etc/dhcp/dhcpd(6).conf`        | 'The full path to the DHCP server configuration on disk             |                     |
 | `cookbook`             | String        | `/etc/dhcp/dhcpd(6).d/classes.d` | Cookbook to source configuration file template from                 |                     |
 | `template`             | String        | `/etc/dhcp/dhcpd(6).d/classes.d` | Template to use to generate the configuration file                  |                     |
 | `owner`                | String        | Platform dependant               | Owner of the generated configuration file                           |                     |
@@ -39,6 +38,8 @@ Introduced: v7.0.0
 | `failover`             | Hash          | `nil`                            | DHCP failover configuration                                         |                     |
 | `include_files`        | Array         | `nil`                            | Additional configuration files to include                           |                     |
 | `extra_lines`          | String, Array | `nil`                            | Extra lines to append to the configuration file                     |                     |
+| `env_file`             | String        | Platform dependant               | Service environment file, mostly unused by modern distributions     |                     |
+| `env_file_lines`       | String, Array | `nil`                            | Service environment file lines                                      |                     |
 
 ## Examples
 

--- a/documentation/dhcp_service.md
+++ b/documentation/dhcp_service.md
@@ -23,6 +23,7 @@ Introduced: v7.0.0
 | `ip_version`           | Symbol        | `:ipv4`                       | Select DHCP or DHCPv6 server to configure                              | `:ipv4`, `:ipv6`    |
 | `service_name`         | String        | `nil`                         | Custom service name                                                    |                     |
 | `systemd_unit_content` | String, Hash  | Platform dependant            | systemd unit file content for service                                  |                     |
+| `config_file`          | String        | `/etc/dhcp/dhcpd(6).conf`     | 'The full path to the DHCP server configuration on disk                |                     |
 | `config_test`          | True, False   | `true`                        | Perform configuration test before starting, restarting or reload       |                     |
 
 ## Examples

--- a/documentation/dhcp_service.md
+++ b/documentation/dhcp_service.md
@@ -23,6 +23,7 @@ Introduced: v7.0.0
 | `ip_version`           | Symbol        | `:ipv4`                       | Select DHCP or DHCPv6 server to configure                              | `:ipv4`, `:ipv6`    |
 | `service_name`         | String        | `nil`                         | Custom service name                                                    |                     |
 | `systemd_unit_content` | String, Hash  | Platform dependant            | systemd unit file content for service                                  |                     |
+| `config_test`          | True, False   | `true`                        | Perform configuration test before starting, restarting or reload       |                     |
 
 ## Examples
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -103,6 +103,10 @@ module Dhcp
         %w(groups.d hosts.d subnets.d shared_networks.d classes.d)
       end
 
+      def dhcpd_config_test_command(ip_version, config_file)
+        "dhcpd -#{ip_version.eql?(:ipv4) ? '4' : '6'} -d -t -T -cf #{config_file}"
+      end
+
       def dhcpd_lib_dir
         if platform_family?('debian')
           '/var/lib/dhcp'
@@ -181,7 +185,7 @@ module Dhcp
         end
       end
 
-      def dhcpd_systemd_unit_content(ip_version)
+      def dhcpd_systemd_unit_content(ip_version, config_file)
         raise 'Invalid ip_version' unless ip_version.is_a?(Symbol) && %i(ipv4 ipv6).include?(ip_version)
         dhcp6 = ip_version.eql?(:ipv6)
 
@@ -198,13 +202,13 @@ module Dhcp
               ],
               'ConditionPathExists' => [
                 '/etc/sysconfig/dhcpd',
-                "|/etc/dhcp/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.conf",
+                "|#{config_file}",
               ],
             },
             'Service' => {
               'Type' => 'notify',
               'EnvironmentFile' => '-/etc/sysconfig/dhcpd',
-              'ExecStart' => "/usr/sbin/dhcpd -f #{dhcp6 ? '-6' : '-4'} -cf /etc/dhcp/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.conf -user dhcpd -group dhcpd --no-pid $DHCPDARGS",
+              'ExecStart' => "/usr/sbin/dhcpd -f #{dhcp6 ? '-6' : '-4'} -cf #{config_file} -user dhcpd -group dhcpd --no-pid $DHCPDARGS",
               'StandardError' => 'null',
             },
             'Install' => {
@@ -223,13 +227,13 @@ module Dhcp
               ],
               'ConditionPathExists' => [
                 '/etc/default/isc-dhcp-server',
-                "|/etc/dhcp/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.conf",
+                "|#{config_file}",
               ],
             },
             'Service' => {
               'EnvironmentFile' => '/etc/default/isc-dhcp-server',
               'RuntimeDirectory' => 'dhcp-server',
-              'ExecStart' => "/usr/sbin/dhcpd -f #{dhcp6 ? '-6' : '-4'} -cf /etc/dhcp/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.conf -pf /run/dhcp-server/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.pid $INTERFACES",
+              'ExecStart' => "/usr/sbin/dhcpd -f #{dhcp6 ? '-6' : '-4'} -cf #{config_file} -pf /run/dhcp-server/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.pid $INTERFACES",
             },
             'Install' => {
               'WantedBy' => 'multi-user.target',
@@ -247,13 +251,13 @@ module Dhcp
               ],
               'ConditionPathExists' => [
                 '/etc/default/isc-dhcp-server',
-                "|/etc/dhcp/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.conf",
+                "|#{config_file}",
               ],
             },
             'Service' => {
               'EnvironmentFile' => '/etc/default/isc-dhcp-server',
               'RuntimeDirectory' => 'dhcp-server',
-              'ExecStart' => "/usr/sbin/dhcpd -f #{dhcp6 ? '-6' : '-4'} -cf /etc/dhcp/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.conf -user dhcpd -group dhcpd -pf /run/dhcp-server/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.pid $INTERFACES",
+              'ExecStart' => "/usr/sbin/dhcpd -f #{dhcp6 ? '-6' : '-4'} -cf #{config_file} -user dhcpd -group dhcpd -pf /run/dhcp-server/#{dhcp6 ? 'dhcpd6' : 'dhcpd'}.pid $INTERFACES",
             },
             'Install' => {
               'WantedBy' => 'multi-user.target',

--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -32,7 +32,6 @@ module Dhcp
 
       def manage_list_resource(directory, config_file, action)
         begin
-
           list = find_resource!(:template, "#{directory}/list.conf")
         rescue Chef::Exceptions::ResourceNotFound
           list = create_list_resource(directory)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs and configures DHCP'
 chef_version      '>= 14.0'
 source_url        'https://github.com/sous-chefs/dhcp'
 issues_url        'https://github.com/sous-chefs/dhcp/issues'
-version           '7.0.0'
+version           '7.1.0'
 
 supports 'debian'
 supports 'ubuntu'

--- a/spec/unit/recipes/service_spec.rb
+++ b/spec/unit/recipes/service_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'dhcp_service' do
+  step_into :dhcp_service
+  platform 'centos'
+
+  context 'create a dhcpd service' do
+    recipe do
+      dhcp_service 'dhcpd' do
+        action [:create, :enable, :start]
+      end
+    end
+
+    describe 'creates a systemd unit file' do
+      it { is_expected.to create_systemd_unit('dhcpd.service') }
+    end
+
+    describe 'enables and starts dhcpd' do
+      it { is_expected.to enable_service('dhcpd') }
+      it { is_expected.to start_service('dhcpd') }
+      it { is_expected.to_not run_execute('Run pre service start dhcpd configuration test.') }
+    end
+  end
+
+  context 'create a dhcpd6 service ' do
+    recipe do
+      dhcp_service 'dhcpd6' do
+        ip_version :ipv6
+        action [:create, :enable, :start]
+      end
+    end
+
+    describe 'creates a systemd unit file' do
+      it { is_expected.to create_systemd_unit('dhcpd6.service') }
+    end
+
+    describe 'enables and starts dhcpd6' do
+      it { is_expected.to enable_service('dhcpd6') }
+      it { is_expected.to start_service('dhcpd6') }
+      it { is_expected.to_not run_execute('Run pre service start dhcpd6 configuration test.') }
+    end
+  end
+end


### PR DESCRIPTION
# Description

Add the option (and enable by default) to run a configuration test before running a `:start`, `:restart` or `:reload` action to help prevent killing a working DHCP server by a bad configuration change.

## Issues Resolved

- n/a

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
