### PR TITLE
Fix configuration test running every Chef run regardless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
+## 7.1.1 (2020-05-20)
+
+- Fix configuration test running every chef run regardless of service action - [@bmhughes](https://github.com/bmhughes)
+
 ## 7.1.0 (2020-05-18)
 
-- Add configuration test option to the `dhcp_service` resource
+- Add configuration test option to the `dhcp_service` resource - [@bmhughes](https://github.com/bmhughes)
 
 ## 7.0.0 (2020-04-17)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs and configures DHCP'
 chef_version      '>= 14.0'
 source_url        'https://github.com/sous-chefs/dhcp'
 issues_url        'https://github.com/sous-chefs/dhcp/issues'
-version           '7.1.0'
+version           '7.1.1'
 
 supports 'debian'
 supports 'ubuntu'


### PR DESCRIPTION
# Description

Fix the irretation of a configuration test running every chef run regardless of service action

## Issues Resolved

- None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
