### PR TITLE
Fix the service resource not using the unit file content property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - resolved cookstyle error: libraries/helpers.rb:154:24 refactor: `ChefCorrectness/InvalidPlatformFamilyInCase`
 - resolved cookstyle error: libraries/helpers.rb:161:14 refactor: `ChefCorrectness/InvalidPlatformFamilyInCase`
 - resolved cookstyle error: libraries/helpers.rb:193:44 refactor: `ChefCorrectness/InvalidPlatformInCase`
+- Fix the service resource not using the unit file content property
 
 ## 7.1.1 (2020-05-20)
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -29,7 +29,7 @@ property :service_name, String,
           description: 'Override the default service names'
 
 property :systemd_unit_content, [String, Hash],
-          default: lazy { dhcpd_systemd_unit_content(ip_version) },
+          default: lazy { dhcpd_systemd_unit_content(ip_version, config_file) },
           description: 'Override the systemd unit file contents'
 
 property :config_file, String,
@@ -63,7 +63,7 @@ end
 action :create do
   with_run_context :root do
     edit_resource(:systemd_unit, new_resource.service_name) do |new_resource|
-      content new_resource.dhcpd_systemd_unit_content(new_resource.ip_version, new_resource.config_file)
+      content new_resource.systemd_unit_content
       triggers_reload true
       verify false
 


### PR DESCRIPTION
# Description

Fix the service resource not using the unit file content property.

## Issues Resolved

None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
