### PR TITLE
Delete service resource on a config test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix the service resource not using the unit file content property
 - Slightly simplified the libraries with a platform helper
 - Fix verification of the isc-dhcp-server configuration on Ubuntu
+- Ensure that a service restart does not occur upon a configuration test failure
 
 ## 7.1.1 (2020-05-20)
 


### PR DESCRIPTION
# Description

The exception triggered by the execute resource upon a configuration test failure would not always prevent the service from being restarted with a bad configuration allowing a service impact potential. Delete the service resource upon a test failure to ensure that the service action is never attempted.

## Issues Resolved

n/a

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
