### PR TITLE
Fix the pre service action configuration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - 'centos-6'
           - 'centos-7'
           - 'centos-8'
-          - 'fedora-31'
+          - 'fedora-latest'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
         suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Enhance the pre-service action configuration test to remove compile/converge bug - [@bmhughes](https://github.com/bmhughes)
+
 ## 7.2.0 (2020-07-10)
 
 - resolved cookstyle error: libraries/helpers.rb:120:44 refactor: `ChefCorrectness/InvalidPlatformInCase`

--- a/documentation/dhcp_service.md
+++ b/documentation/dhcp_service.md
@@ -23,8 +23,9 @@ Introduced: v7.0.0
 | `ip_version`           | Symbol        | `:ipv4`                       | Select DHCP or DHCPv6 server to configure                              | `:ipv4`, `:ipv6`    |
 | `service_name`         | String        | `nil`                         | Custom service name                                                    |                     |
 | `systemd_unit_content` | String, Hash  | Platform dependant            | systemd unit file content for service                                  |                     |
-| `config_file`          | String        | `/etc/dhcp/dhcpd(6).conf`     | 'The full path to the DHCP server configuration on disk                |                     |
+| `config_file`          | String        | `/etc/dhcp/dhcpd(6).conf`     | The full path to the DHCP server configuration on disk                 |                     |
 | `config_test`          | True, False   | `true`                        | Perform configuration test before starting, restarting or reload       |                     |
+| `config_test_fail_action` | Symbol     | `:raise`                      | Action to perform upon a configuration test failure                    | `:raise`, `:log`    |
 
 ## Examples
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -23,9 +23,9 @@ platforms:
     driver:
       image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
-  - name: fedora-31
+  - name: fedora-latest
     driver:
-      image: dokken/fedora-31
+      image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
   - name: amazonlinux-2
     driver:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,7 +18,7 @@ platforms:
   - name: centos-6
   - name: centos-7
   - name: centos-8
-  - name: fedora-31
+  - name: fedora-latest
   - name: amazonlinux-2
   - name: debian-9
   - name: debian-10

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -40,25 +40,50 @@ property :config_test, [true, false],
           default: true,
           description: 'Perform configuration file test before performing service action'
 
+property :config_test_fail_action, Symbol,
+          equal_to: %i(raise log),
+          default: :raise,
+          description: 'Action to perform upon configuration test failure.'
+
 action_class do
   def do_service_action(resource_action)
     with_run_context(:root) do
-      begin
-        edit_resource(:execute, "Run pre service #{resource_action} #{dhcpd_service_name(new_resource.ip_version)} configuration test.") do
-          command dhcpd_config_test_command(new_resource.ip_version, new_resource.config_file)
-          only_if { new_resource.config_test && %i(start restart reload).include?(resource_action) && ::File.exist?(new_resource.config_file) }
-          user dhcpd_user
+      if %i(start restart reload).include?(resource_action)
+        edit_resource(:ruby_block, "Run pre #{new_resource.service_name} #{resource_action} configuration test") do
+          block do
+            begin
+              if new_resource.config_test
+                cmd = Mixlib::ShellOut.new(dhcpd_config_test_command(new_resource.ip_version, new_resource.config_file))
+                cmd.user = dhcpd_user
+                cmd.run_command.error!
+                Chef::Log.info("Configuration test passed, creating #{new_resource.service_name} #{new_resource.declared_type} resource with action #{resource_action}")
+              else
+                Chef::Log.info("Configuration test disabled, creating #{new_resource.service_name} #{new_resource.declared_type} resource with action #{resource_action}")
+              end
+
+              edit_resource(:service, new_resource.service_name.delete_suffix('.service')) do
+                action :nothing
+                delayed_action resource_action
+              end
+            rescue Mixlib::ShellOut::ShellCommandFailed
+              if new_resource.config_test_fail_action.eql?(:log)
+                Chef::Log.error("Configuration test failed, #{new_resource.service_name} #{resource_action} action aborted!\n\nError\n-----\n#{cmd.stderr}")
+              else
+                raise "Configuration test failed, #{new_resource.service_name} #{resource_action} action aborted!\n\nError\n-----\n#{cmd.stderr}"
+              end
+            end
+          end
+
+          only_if { ::File.exist?(new_resource.config_file) }
+
           action :nothing
+          delayed_action :run
         end
-      rescue Mixlib::ShellOut::ShellCommandFailed
-        delete_resource!(:service, new_resource.service_name.delete_suffix('.service'))
-      end
-
-      edit_resource(:service, new_resource.service_name.delete_suffix('.service')) do
-        notifies :run, "execute[Run pre service #{resource_action} #{dhcpd_service_name(new_resource.ip_version)} configuration test.]", :before
-
-        action :nothing
-        delayed_action resource_action
+      else
+        edit_resource(:service, new_resource.service_name.delete_suffix('.service')) do
+          action :nothing
+          delayed_action resource_action
+        end
       end
     end
   end

--- a/spec/unit/recipes/service_spec.rb
+++ b/spec/unit/recipes/service_spec.rb
@@ -17,8 +17,8 @@ describe 'dhcp_service' do
 
     describe 'enables and starts dhcpd' do
       it { is_expected.to enable_service('dhcpd') }
-      it { is_expected.to start_service('dhcpd') }
-      it { is_expected.to_not run_execute('Run pre service start dhcpd configuration test.') }
+      it { is_expected.to_not start_service('dhcpd') }
+      it { is_expected.to nothing_ruby_block('Run pre dhcpd.service start configuration test') }
     end
   end
 
@@ -36,8 +36,8 @@ describe 'dhcp_service' do
 
     describe 'enables and starts dhcpd6' do
       it { is_expected.to enable_service('dhcpd6') }
-      it { is_expected.to start_service('dhcpd6') }
-      it { is_expected.to_not run_execute('Run pre service start dhcpd6 configuration test.') }
+      it { is_expected.to_not start_service('dhcpd6') }
+      it { is_expected.to nothing_ruby_block('Run pre dhcpd6.service start configuration test') }
     end
   end
 end


### PR DESCRIPTION
# Description

Move the configuration test into a ruby_block to ensure it is ran during convergence rather than during compilation.

## Issues Resolved

- None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
